### PR TITLE
Signmode forces fullscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.log
 *.old
 *.pid
+/.vscode

--- a/coc_wifiscoring/templates/signmode.html
+++ b/coc_wifiscoring/templates/signmode.html
@@ -75,11 +75,13 @@
 <!-- https://howchoo.com/g/yjfjmty1zjb/how-to-animate-scroll-in-jquery -->
 <script>
 function forceFullScreen() {
+// Broswer security features prevent this from working as intended. 
+// In firefox, change "full-screen-api.allow-trusted-requests-only" to false.
   var doc = window.document;
   var docEl = doc.documentElement;
 
   var requestFullScreen = docEl.requestFullscreen || docEl.mozRequestFullScreen || docEl.webkitRequestFullScreen || docEl.msRequestFullscreen;
-  var cancelFullScreen = doc.exitFullscreen || doc.mozCancelFullScreen || doc.webkitExitFullscreen || doc.msExitFullscreen;
+//   var cancelFullScreen = doc.exitFullscreen || doc.mozCancelFullScreen || doc.webkitExitFullscreen || doc.msExitFullscreen;
 
   if(!doc.fullscreenElement && !doc.mozFullScreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
     requestFullScreen.call(docEl);

--- a/coc_wifiscoring/templates/signmode.html
+++ b/coc_wifiscoring/templates/signmode.html
@@ -74,8 +74,24 @@
 {% block bottomscripts %}
 <!-- https://howchoo.com/g/yjfjmty1zjb/how-to-animate-scroll-in-jquery -->
 <script>
+function forceFullScreen() {
+  var doc = window.document;
+  var docEl = doc.documentElement;
+
+  var requestFullScreen = docEl.requestFullscreen || docEl.mozRequestFullScreen || docEl.webkitRequestFullScreen || docEl.msRequestFullscreen;
+  var cancelFullScreen = doc.exitFullscreen || doc.mozCancelFullScreen || doc.webkitExitFullscreen || doc.msExitFullscreen;
+
+  if(!doc.fullscreenElement && !doc.mozFullScreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
+    requestFullScreen.call(docEl);
+  }
+//   else {
+//     cancelFullScreen.call(doc);
+//   }
+}
+
 $(function() { 
     $( document ).ready( function() {
+		forceFullScreen();
         $(document).scrollTop(0)
 		var bottom = $(document).height() - $(window).height();
 		var pps = 80 // pixels per second. ~80 is good.
@@ -91,5 +107,8 @@ $(function() {
                                  });
     }); 
 });
+
+
+
 </script>
 {% endblock %}


### PR DESCRIPTION
Small improvement for #19 

Call the full-screen api when loading the sign mode page. 

In firefox, requires the browser client to have `full-screen-api.allow-trusted-requests-only` set to `False`. Didn't test in other browsers. 