### PR TITLE
fix special chars in name, missing xml nodes in PersonResult

### DIFF
--- a/coc_wifiscoring/ETL.py
+++ b/coc_wifiscoring/ETL.py
@@ -129,20 +129,20 @@ def getClassCourseEtree(CR, nstag):
     except:
         return None
 
-def getNameEtree(PR, nstag_f, nstag_l):
+def getNameEtree(PR, nstags):
     try:
-        first = PR[0][0].find(nstag_f).text
+        first = PR.find(nstags['Person']).find(nstags['Name']).find(nstags['Given']).text
     except:
         first = None
     try:
-        last = PR[0][0].find(nstag_l).text
+        last = PR.find(nstags['Person']).find(nstags['Name']).find(nstags['Family']).text
     except:
         last = None
-    return '{} {}'.format(first, last).strip()
+    return u'{} {}'.format(first, last).strip()
 
-def getClubShortEtree(PR, nstag):
+def getClubShortEtree(PR, nstags):
     try:
-        clubcode = PR[1].find(nstag)
+        clubcode = PR.find(nstags['Org']).find(nstags['ShortName'])
         return clubcode.text
     except:
         return None
@@ -171,14 +171,18 @@ def getRunners(file):
         'ShortName':'{http://www.orienteering.org/datastandard/3.0}ShortName',
         'Name':'{http://www.orienteering.org/datastandard/3.0}Name',
         'PR':'{http://www.orienteering.org/datastandard/3.0}PersonResult',
+        'Person':'{http://www.orienteering.org/datastandard/3.0}Person',
         'Given':'{http://www.orienteering.org/datastandard/3.0}Given',
         'Family':'{http://www.orienteering.org/datastandard/3.0}Family',
+        'Org':'{http://www.orienteering.org/datastandard/3.0}Organisation',
+        'Result':'{http://www.orienteering.org/datastandard/3.0}Result',
         'ControlCard':'{http://www.orienteering.org/datastandard/3.0}ControlCard',
         'StartTime':'{http://www.orienteering.org/datastandard/3.0}StartTime',
         'FinishTime':'{http://www.orienteering.org/datastandard/3.0}FinishTime',
         'Time':'{http://www.orienteering.org/datastandard/3.0}Time',
         'BibNumber':'{http://www.orienteering.org/datastandard/3.0}BibNumber',
         'Status':'{http://www.orienteering.org/datastandard/3.0}Status',
+        
     }
 
     runners = []
@@ -193,13 +197,16 @@ def getRunners(file):
             CR_Course = getClassCourseEtree(CR, iof3tags['Name'])
 
             for PR in CR.iter(iof3tags['PR']):
-                PR_R = PR[2] # <Result> node contains most of the data
+                try:
+                    PR_R = PR.find(iof3tags['Result'])
+                except:
+                    continue
                 runner = {}
                 runner['estick'] = getResultStrEtree(PR_R, iof3tags['ControlCard'])
                 runner['start'] = getResultStrEtree(PR_R, iof3tags['StartTime'])
-                runner['club'] = getClubShortEtree(PR, iof3tags['ShortName'])
+                runner['club'] = getClubShortEtree(PR, iof3tags)
                 runner['bib'] = getResultStrEtree(PR_R, iof3tags['BibNumber'])
-                runner['name'] = getNameEtree(PR, iof3tags['Given'], iof3tags['Family'])
+                runner['name'] = getNameEtree(PR, iof3tags)
                 runner['class_code'] = CR_ShortName
                 runner['course'] = CR_Course
                 runner['finish'] = getResultStrEtree(PR_R, iof3tags['FinishTime'])

--- a/coc_wifiscoring/ETL.py
+++ b/coc_wifiscoring/ETL.py
@@ -197,9 +197,8 @@ def getRunners(file):
             CR_Course = getClassCourseEtree(CR, iof3tags['Name'])
 
             for PR in CR.iter(iof3tags['PR']):
-                try:
-                    PR_R = PR.find(iof3tags['Result'])
-                except:
+                PR_R = PR.find(iof3tags['Result'])
+                if PR_R == None:
                     continue
                 runner = {}
                 runner['estick'] = getResultStrEtree(PR_R, iof3tags['ControlCard'])

--- a/coc_wifiscoring/apicontroller.py
+++ b/coc_wifiscoring/apicontroller.py
@@ -44,7 +44,7 @@ def results(event):
             timeStart_buildDB = time.time()
             for r in results:
                 result_dict = { 'sicard': int(r['estick'] if r['estick']>0 else -1),
-                                'name': str(r['name']),
+                                'name': r['name'], # don't "cast" to (ascii) str!
                                 'bib': int(r['bib'] if r['bib']>0 else -1),
                                 'class_code': str(r['class_code']),
                                 'club_code': str(r['club']),


### PR DESCRIPTION
Fixes for:
#30 - save name as unicode, and pass it all the way through. No issues in testing.
#31 - never lookup nodes on PersonResult by numeric index, always look up using the xml node name.